### PR TITLE
unregisterReceiverする時にnullチェックを行う

### DIFF
--- a/android/src/main/java/slayer/accessibility/service/flutter_accessibility_service/FlutterAccessibilityServicePlugin.java
+++ b/android/src/main/java/slayer/accessibility/service/flutter_accessibility_service/FlutterAccessibilityServicePlugin.java
@@ -169,7 +169,10 @@ public class FlutterAccessibilityServicePlugin implements FlutterPlugin, Activit
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
         channel.setMethodCallHandler(null);
         eventChannel.setStreamHandler(null);
-        context.unregisterReceiver(actionsReceiver);
+        if (accessibilityReceiver != null) {
+            context.unregisterReceiver(accessibilityReceiver);
+            accessibilityReceiver = null;
+        }
     }
     @SuppressLint("WrongConstant")
     @Override
@@ -195,8 +198,10 @@ public class FlutterAccessibilityServicePlugin implements FlutterPlugin, Activit
 
     @Override
     public void onCancel(Object arguments) {
-        context.unregisterReceiver(accessibilityReceiver);
-        accessibilityReceiver = null;
+        if (accessibilityReceiver != null) {
+            context.unregisterReceiver(accessibilityReceiver);
+            accessibilityReceiver = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
`java.lang.IllegalArgumentException: Receiver not registered`の対応

unregisterReceiverする時にnullチェックを行う

参考：[公式](https://developer.android.com/reference/android/content/Context#unregisterReceiver(android.content.BroadcastReceiver))

