### PR TITLE
fix: 【不具合】端末の設定画面でプッシュ通知をON→OFFにし、Offly起動すると「繰り返しエラー」が表示される

### DIFF
--- a/android/src/main/java/slayer/accessibility/service/flutter_accessibility_service/AccessibilityListener.java
+++ b/android/src/main/java/slayer/accessibility/service/flutter_accessibility_service/AccessibilityListener.java
@@ -119,20 +119,25 @@ public class AccessibilityListener extends AccessibilityService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        boolean globalAction = intent.getBooleanExtra(INTENT_GLOBAL_ACTION, false);
-        boolean systemActions = intent.getBooleanExtra(INTENT_SYSTEM_GLOBAL_ACTIONS, false);
-        if (systemActions && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-            List<Integer> actions = getSystemActions().stream().map(AccessibilityNodeInfo.AccessibilityAction::getId).collect(Collectors.toList());
-            Intent broadcastIntent = new Intent(BROD_SYSTEM_GLOBAL_ACTIONS);
-            broadcastIntent.putIntegerArrayListExtra("actions", new ArrayList<>(actions));
-            sendBroadcast(broadcastIntent);
+        try {
+            boolean globalAction = intent.getBooleanExtra(INTENT_GLOBAL_ACTION, false);
+            boolean systemActions = intent.getBooleanExtra(INTENT_SYSTEM_GLOBAL_ACTIONS, false);
+            if (systemActions && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                List<Integer> actions = getSystemActions().stream().map(AccessibilityNodeInfo.AccessibilityAction::getId).collect(Collectors.toList());
+                Intent broadcastIntent = new Intent(BROD_SYSTEM_GLOBAL_ACTIONS);
+                broadcastIntent.putIntegerArrayListExtra("actions", new ArrayList<>(actions));
+                sendBroadcast(broadcastIntent);
+            }
+            if (globalAction) {
+                int actionId = intent.getIntExtra(INTENT_GLOBAL_ACTION_ID, 8);
+                performGlobalAction(actionId);
+            }
+            Log.d("CMD_STARTED", "onStartCommand: " + startId);
+            return START_STICKY;
+        } catch (Exception ex) {
+            Log.e("EVENT", "onStartCommand: " + ex.getMessage());
+            return START_NOT_STICKY;
         }
-        if (globalAction) {
-            int actionId = intent.getIntExtra(INTENT_GLOBAL_ACTION_ID, 8);
-            performGlobalAction(actionId);
-        }
-        Log.d("CMD_STARTED", "onStartCommand: " + startId);
-        return START_STICKY;
     }
 
 


### PR DESCRIPTION
#1 のブランチから派生しているのでそちらの diff も表示されてます。

## What

https://www.notion.so/team-b/ON-OFF-Offly-13e9518fc3758032aeb4eb8cdacf5593

## How

- `AccessibilityListener ` の `onStartCommand` を try catch で囲んで exception を吐いた場合は `START_NOT_STICKY` を返すよう修正

## Why ( option )

問題の動作を行った時に以下のエラーを吐いていたのを確認したのでこちらを catch するようにした。
（おそらく intent が null で来てるのが原因？）

```
Process: jp.momentia.offly.local, PID: 22958
java.lang.RuntimeException: Unable to start service slayer.accessibility.service.flutter_accessibility_service.AccessibilityListener@c05aaab with null: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.content.Intent.getBooleanExtra(java.lang.String, boolean)' on a null object reference 
at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:5100) 
at android.app.ActivityThread.-$$Nest$mhandleServiceArgs(Unknown Source:0) 
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2432) 
at android.os.Handler.dispatchMessage(Handler.java:107) 
at android.os.Looper.loopOnce(Looper.java:232)
at android.os.Looper.loop(Looper.java:317)
at android.app.ActivityThread.main(ActivityThread.java:8592)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)

Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.content.Intent.getBooleanExtra(java.lang.String, boolean)' on a null object reference
at slayer.accessibility.service.flutter_accessibility_service.AccessibilityListener.onStartCommand(AccessibilityListener.java:122)
at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:5082)
at android.app.ActivityThread.-$$Nest$mhandleServiceArgs(Unknown Source:0) 
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2432) 
at android.os.Handler.dispatchMessage(Handler.java:107) 
at android.os.Looper.loopOnce(Looper.java:232) 
at android.os.Looper.loop(Looper.java:317) 
at android.app.ActivityThread.main(ActivityThread.java:8592) 
at java.lang.reflect.Method.invoke(Native Method) 
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580) 
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878) 
```

## 特にレビューして欲しい部分 ( option )

## Links ( option )

## Screenshot ( option )

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="300" /> | <img src="" width="300" /> |
